### PR TITLE
Create BitBoard struct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 
 # vs
 .vs
+CMakeSettings.json
 
 build/
 out/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,4 +8,7 @@ ELSE()
 add_compile_options(-g3)
 ENDIF()
 
-add_executable(Engine src/engine/engine.cpp src/engine/boardstate.cpp)
+add_executable(Engine   
+    src/engine/engine.cpp 
+    src/engine/boardstate.cpp
+)

--- a/src/engine/bitboard.h
+++ b/src/engine/bitboard.h
@@ -1,0 +1,127 @@
+#include <cstdint>
+
+#define BOARD_ROW 8
+#define BOARD_COL 1
+
+#define BOARD_WHITE_SQUARE_MASK 0x55AA55AA55AA55AA
+#define BOARD_BLACK_SQUARE_MASK ~BOARD_WHITE_SQUARE_MASK
+
+#define FIRST_RANK   0x00000000000000FF
+#define SECOND_RANK  0x000000000000FF00
+#define THIRD_RANK   0x0000000000FF0000
+#define FOURTH_RANK  0x00000000FF000000
+#define FIFTH_RANK   0x000000FF00000000
+#define SIXTH_RANK   0x0000FF0000000000
+#define SEVENTH_RANK 0x00FF000000000000
+#define EIGHTH_RANK  0xFF00000000000000
+
+#define FIRST_FILE   0x0101010101010101
+#define SECOND_FILE  0x0202020202020202
+#define THIRD_FILE   0x0404040404040404
+#define FOURTH_FILE  0x0808080808080808
+#define FIFTH_FILE   0x1010101010101010
+#define SIXTH_FILE   0x2020202020202020
+#define SEVENTH_FILE 0x4040404040404040
+#define EIGHTH_FILE  0x8080808080808080
+
+
+struct BitBoard {
+    uint64_t board;
+
+    BitBoard(uint64_t b) {
+        board = b;
+    }
+    
+    BitBoard() {
+        board = 0;
+    }
+
+    inline BitBoard reverse() {
+        uint64_t rev = 0;
+        uint64_t board_copy = board;
+        for (int i = 0; i < 64; i++) {
+            rev <<= 1;
+
+            if ((board_copy & 1) == 1) {
+                rev ^= 1;
+            }
+
+            board_copy >>= 1;
+        }
+        return BitBoard(rev);
+    }
+
+    inline void out() {
+        BitBoard to_out = reverse();
+        std::cout << std::bitset<8>((to_out.board & FIRST_RANK  )      ).to_string() << std::endl;
+        std::cout << std::bitset<8>((to_out.board & SECOND_RANK ) >> 8 ).to_string() << std::endl;
+        std::cout << std::bitset<8>((to_out.board & THIRD_RANK  ) >> 16).to_string() << std::endl;
+        std::cout << std::bitset<8>((to_out.board & FOURTH_RANK ) >> 24).to_string() << std::endl;
+        std::cout << std::bitset<8>((to_out.board & FIFTH_RANK  ) >> 32).to_string() << std::endl;
+        std::cout << std::bitset<8>((to_out.board & SIXTH_RANK  ) >> 40).to_string() << std::endl;
+        std::cout << std::bitset<8>((to_out.board & SEVENTH_RANK) >> 48).to_string() << std::endl;
+        std::cout << std::bitset<8>((to_out.board & EIGHTH_RANK ) >> 56).to_string() << std::endl;
+
+
+    }
+};
+
+inline BitBoard operator &(BitBoard lhs, BitBoard rhs) {
+    return BitBoard(lhs.board & rhs.board);
+}
+
+inline BitBoard operator |(BitBoard lhs, BitBoard rhs) {
+    return BitBoard(lhs.board | rhs.board);
+}
+
+inline BitBoard operator ^(BitBoard lhs, BitBoard rhs) {
+    return BitBoard(lhs.board ^ rhs.board);
+}
+
+inline void operator &=(BitBoard& lhs, BitBoard rhs) {
+    lhs.board &= rhs.board;
+}
+
+inline void operator |=(BitBoard& lhs, BitBoard rhs) {
+    lhs.board |= rhs.board;
+}
+
+inline void operator ^=(BitBoard& lhs, BitBoard rhs) {
+    lhs.board ^= rhs.board;
+}
+
+inline BitBoard operator ~(BitBoard b) {
+    return BitBoard(~b.board);
+}
+
+inline BitBoard operator <<(BitBoard lhs, int8_t rhs) {
+    return BitBoard(lhs.board << rhs);
+}
+
+inline BitBoard operator >>(BitBoard lhs, uint8_t rhs) {
+    return BitBoard(lhs.board >> rhs);
+}
+
+inline void operator <<=(BitBoard& lhs, int8_t rhs) {
+    lhs.board <<= rhs;
+}
+
+inline void operator >>=(BitBoard& lhs, int8_t rhs) {
+    lhs.board >>= rhs;
+}
+
+inline bool operator ==(BitBoard lhs, BitBoard rhs) {
+    return lhs.board == rhs.board;
+}
+
+inline bool operator !=(BitBoard lhs, BitBoard rhs) {
+    return lhs.board != rhs.board;
+}
+
+inline bool operator >(BitBoard lhs, uint64_t rhs) {
+    return lhs.board > rhs;
+}
+
+inline bool operator <(BitBoard lhs, uint64_t rhs) {
+    return lhs.board < rhs;
+}

--- a/src/engine/boardstate.cpp
+++ b/src/engine/boardstate.cpp
@@ -160,7 +160,7 @@ std::unordered_map<uint16_t, uint8_t> get_rank_attacks() {
 	return map;
 }
 
-inline constexpr BitBoard translate(BitBoard pieces, int8_t row_mod, int8_t col_mod) {
+inline BitBoard translate(BitBoard pieces, int8_t row_mod, int8_t col_mod) {
     // row_mod is the number of rows down, col_mod is the number of colums left
     // Work out which columns would be in if wrapping was allowed
 	// Shift all the bits by the required amount
@@ -242,7 +242,7 @@ BitBoard BoardState::pseudo_legal_pawn_moves(Colour colour) {
 
 	bool white = (colour == COL_WHITE);
 
-	uint64_t allsquares = 0;
+	BitBoard allsquares = 0;
 
 	if (white) {
 		// Check if the pawn is on the second rank

--- a/src/engine/boardstate.h
+++ b/src/engine/boardstate.h
@@ -4,30 +4,7 @@
 #include <bitset>
 
 #include "pieces.h"
-
-#define BOARD_ROW 8
-#define BOARD_COL 1
-
-#define BOARD_WHITE_SQUARE_MASK 0x55AA55AA55AA55AA
-#define BOARD_BLACK_SQUARE_MASK ~BOARD_WHITE_SQUARE_MASK
-
-#define FIRST_RANK 0xFF
-#define SECOND_RANK 0xFF00
-#define THIRD_RANK 0xFF0000
-#define FOURTH_RANK 0xFF000000
-#define FIFTH_RANK 0xFF00000000
-#define SIXTH_RANK 0xFF0000000000
-#define SEVENTH_RANK 0xFF000000000000
-#define EIGHTH_RANK 0xFF00000000000000
-
-#define FIRST_FILE 0x0101010101010101
-#define SECOND_FILE 0x0202020202020202
-#define THIRD_FILE 0x0404040404040404
-#define FOURTH_FILE 0x0808080808080808
-#define FIFTH_FILE 0x1010101010101010
-#define SIXTH_FILE 0x2020202020202020
-#define SEVENTH_FILE 0x4040404040404040
-#define EIGHTH_FILE 0x8080808080808080
+#include "bitboard.h"
 
 std::unordered_map<uint64_t, uint64_t> get_file_mask();
 std::unordered_map<uint64_t, uint64_t> get_rank_mask();
@@ -54,108 +31,6 @@ std::unordered_map<uint64_t, uint64_t> get_diag_mask_nw();
 //     pieces_knights: Has a bit where all the knights are.
 //     pieces_bishops: Has a bit where all the bishops are.
 //     pieces_pawns: Has a bit where all the pawns are.
-
-
-struct BitBoard {
-    uint64_t board;
-
-    BitBoard(uint64_t b) {
-        board = b;
-    }
-    
-    BitBoard() {
-        board = 0;
-    }
-
-    inline BitBoard reverse() {
-        uint64_t rev = 0;
-        uint64_t board_copy = board;
-        for (int i = 0; i < 64; i++) {
-            rev <<= 1;
-
-            if ((board_copy & 1) == 1) {
-                rev ^= 1;
-            }
-
-            board_copy >>= 1;
-        }
-        return BitBoard(rev);
-    }
-
-    inline void out() {
-        BitBoard to_out = reverse();
-        std::cout << std::bitset<8>(to_out.board & 0xFF).to_string() << std::endl;
-        std::cout << std::bitset<8>((to_out.board & 0xFF00) >> 8).to_string() << std::endl;
-        std::cout << std::bitset<8>((to_out.board & 0xFF0000) >> 16).to_string() << std::endl;
-        std::cout << std::bitset<8>((to_out.board & 0xFF000000) >> 24).to_string() << std::endl;
-        std::cout << std::bitset<8>((to_out.board & 0xFF00000000) >> 32).to_string() << std::endl;
-        std::cout << std::bitset<8>((to_out.board & 0xFF0000000000) >> 40).to_string() << std::endl;
-        std::cout << std::bitset<8>((to_out.board & 0xFF000000000000) >> 48).to_string() << std::endl;
-        std::cout << std::bitset<8>((to_out.board & 0xFF00000000000000) >> 56).to_string() << std::endl;
-
-
-    }
-};
-
-inline BitBoard operator &(BitBoard lhs, BitBoard rhs) {
-    return BitBoard(lhs.board & rhs.board);
-}
-
-inline BitBoard operator |(BitBoard lhs, BitBoard rhs) {
-    return BitBoard(lhs.board | rhs.board);
-}
-
-inline BitBoard operator ^(BitBoard lhs, BitBoard rhs) {
-    return BitBoard(lhs.board ^ rhs.board);
-}
-
-inline void operator &=(BitBoard& lhs, BitBoard rhs) {
-    lhs.board &= rhs.board;
-}
-
-inline void operator |=(BitBoard& lhs, BitBoard rhs) {
-    lhs.board |= rhs.board;
-}
-
-inline void operator ^=(BitBoard& lhs, BitBoard rhs) {
-    lhs.board ^= rhs.board;
-}
-
-inline BitBoard operator ~(BitBoard b) {
-    return BitBoard(~b.board);
-}
-
-inline BitBoard operator <<(BitBoard lhs, int8_t rhs) {
-    return BitBoard(lhs.board << rhs);
-}
-
-inline BitBoard operator >>(BitBoard lhs, uint8_t rhs) {
-    return BitBoard(lhs.board >> rhs);
-}
-
-inline void operator <<=(BitBoard& lhs, int8_t rhs) {
-    lhs.board <<= rhs;
-}
-
-inline void operator >>=(BitBoard& lhs, int8_t rhs) {
-    lhs.board >>= rhs;
-}
-
-inline bool operator ==(BitBoard lhs, BitBoard rhs) {
-    return lhs.board == rhs.board;
-}
-
-inline bool operator !=(BitBoard lhs, BitBoard rhs) {
-    return lhs.board != rhs.board;
-}
-
-inline bool operator >(BitBoard lhs, uint64_t rhs) {
-    return lhs.board > rhs;
-}
-
-inline bool operator <(BitBoard lhs, uint64_t rhs) {
-    return lhs.board < rhs;
-}
 
 struct BoardState {
     BitBoard pieces_white;

--- a/src/engine/boardstate.h
+++ b/src/engine/boardstate.h
@@ -1,5 +1,7 @@
 #include <cstdint>
 #include <unordered_map>
+#include <iostream>
+#include <bitset>
 
 #include "pieces.h"
 
@@ -53,7 +55,107 @@ std::unordered_map<uint64_t, uint64_t> get_diag_mask_nw();
 //     pieces_bishops: Has a bit where all the bishops are.
 //     pieces_pawns: Has a bit where all the pawns are.
 
-typedef uint64_t BitBoard;
+
+struct BitBoard {
+    uint64_t board;
+
+    BitBoard(uint64_t b) {
+        board = b;
+    }
+    
+    BitBoard() {
+        board = 0;
+    }
+
+    inline BitBoard reverse() {
+        uint64_t rev = 0;
+        uint64_t board_copy = board;
+        for (int i = 0; i < 64; i++) {
+            rev <<= 1;
+
+            if ((board_copy & 1) == 1) {
+                rev ^= 1;
+            }
+
+            board_copy >>= 1;
+        }
+        return BitBoard(rev);
+    }
+
+    inline void out() {
+        BitBoard to_out = reverse();
+        std::cout << std::bitset<8>(to_out.board & 0xFF).to_string() << std::endl;
+        std::cout << std::bitset<8>((to_out.board & 0xFF00) >> 8).to_string() << std::endl;
+        std::cout << std::bitset<8>((to_out.board & 0xFF0000) >> 16).to_string() << std::endl;
+        std::cout << std::bitset<8>((to_out.board & 0xFF000000) >> 24).to_string() << std::endl;
+        std::cout << std::bitset<8>((to_out.board & 0xFF00000000) >> 32).to_string() << std::endl;
+        std::cout << std::bitset<8>((to_out.board & 0xFF0000000000) >> 40).to_string() << std::endl;
+        std::cout << std::bitset<8>((to_out.board & 0xFF000000000000) >> 48).to_string() << std::endl;
+        std::cout << std::bitset<8>((to_out.board & 0xFF00000000000000) >> 56).to_string() << std::endl;
+
+
+    }
+};
+
+inline BitBoard operator &(BitBoard lhs, BitBoard rhs) {
+    return BitBoard(lhs.board & rhs.board);
+}
+
+inline BitBoard operator |(BitBoard lhs, BitBoard rhs) {
+    return BitBoard(lhs.board | rhs.board);
+}
+
+inline BitBoard operator ^(BitBoard lhs, BitBoard rhs) {
+    return BitBoard(lhs.board ^ rhs.board);
+}
+
+inline void operator &=(BitBoard& lhs, BitBoard rhs) {
+    lhs.board &= rhs.board;
+}
+
+inline void operator |=(BitBoard& lhs, BitBoard rhs) {
+    lhs.board |= rhs.board;
+}
+
+inline void operator ^=(BitBoard& lhs, BitBoard rhs) {
+    lhs.board ^= rhs.board;
+}
+
+inline BitBoard operator ~(BitBoard b) {
+    return BitBoard(~b.board);
+}
+
+inline BitBoard operator <<(BitBoard lhs, int8_t rhs) {
+    return BitBoard(lhs.board << rhs);
+}
+
+inline BitBoard operator >>(BitBoard lhs, uint8_t rhs) {
+    return BitBoard(lhs.board >> rhs);
+}
+
+inline void operator <<=(BitBoard& lhs, int8_t rhs) {
+    lhs.board <<= rhs;
+}
+
+inline void operator >>=(BitBoard& lhs, int8_t rhs) {
+    lhs.board >>= rhs;
+}
+
+inline bool operator ==(BitBoard lhs, BitBoard rhs) {
+    return lhs.board == rhs.board;
+}
+
+inline bool operator !=(BitBoard lhs, BitBoard rhs) {
+    return lhs.board != rhs.board;
+}
+
+inline bool operator >(BitBoard lhs, uint64_t rhs) {
+    return lhs.board > rhs;
+}
+
+inline bool operator <(BitBoard lhs, uint64_t rhs) {
+    return lhs.board < rhs;
+}
 
 struct BoardState {
     BitBoard pieces_white;

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -3,33 +3,6 @@
 #include <iostream>
 #include <bitset>
 
-BitBoard reverse_board(BitBoard to_reverse) {
-    BitBoard rev = 0;
-
-    for (int i = 0; i < 64; i++) {
-        rev <<= 1;
-
-        if ((to_reverse & 1) == 1) {
-            rev ^= 1;
-        }
-
-        to_reverse >>= 1;
-    }
-    return rev;
-}
-
-static void out_bitboard(BitBoard to_out) {
-    to_out = reverse_board(to_out);
-    std::cout << std::bitset<8>(to_out & 0xFF).to_string() << std::endl;
-    std::cout << std::bitset<8>((to_out & 0xFF00) >> 8).to_string() << std::endl;
-    std::cout << std::bitset<8>((to_out & 0xFF0000) >> 16).to_string() << std::endl;
-    std::cout << std::bitset<8>((to_out & 0xFF000000) >> 24).to_string() << std::endl;
-    std::cout << std::bitset<8>((to_out & 0xFF00000000) >> 32).to_string() << std::endl;
-    std::cout << std::bitset<8>((to_out & 0xFF0000000000) >> 40).to_string() << std::endl;
-    std::cout << std::bitset<8>((to_out & 0xFF000000000000) >> 48).to_string() << std::endl;
-    std::cout << std::bitset<8>((to_out & 0xFF00000000000000) >> 56).to_string() << std::endl;
-}
-
 int main() {
     BoardState initial_state;
     initial_state.pieces_knights = 0x0001000000001000;
@@ -38,11 +11,11 @@ int main() {
     BitBoard possible_moves;
     possible_moves = initial_state.pseudo_legal_knights_moves(COL_WHITE);
 
-    out_bitboard(initial_state.pieces_knights);
+    initial_state.pieces_knights.out();
 
     std::cout << std::endl;
 
-    out_bitboard(possible_moves);
+    possible_moves.out();
 
 
     return 0;


### PR DESCRIPTION
This should fix #17. That said, I'm not sure if I've followed typical best practice, since I've put quite a lot of code in boardstate.h.
Also, I've added operator overloads for the operators we're using with bitboards, along with bitboard constructors. It may be slightly faster in future to add operator overloads which don't take bitboards in, to avoid going through the constructor, though the compiler may optimise that out.